### PR TITLE
fix: login

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,26 +1,25 @@
 import os
 
 from flask import Flask
-from authlib.integrations.flask_client import OAuth
+from services.common.models import db, migrate
+from services.common.oauth import oauth
+
 from services.admin_service.routes import admin_bp, login_bp
 from services.map_service.routes import map_bp
 from services.reservation_service.routes import parkinglot_bp
 from services.reservation_service.reservation_route import reservation_bp
-from services.common.models import db, migrate
-from flask_migrate import Migrate
-
 # from services.reservation_detail_service.routes import reservation_detail_bp
-from flask_sqlalchemy import SQLAlchemy
-from dotenv import load_dotenv
 
 
 def create_app():
     app = Flask(__name__)
     app.config.from_pyfile('config.py')
-   # load_dotenv(ENV_PATH)
+    app.secret_key = os.urandom(24)
+
+
 
     # 📌 OAuth 설정
-    oauth = OAuth(app)
+    oauth.init_app(app)
     app.config['CLIENT_SECRET'] = os.getenv("CLIENT_SECRET")
     oauth.register(
         name='oidc',
@@ -32,23 +31,27 @@ def create_app():
     )
 
 
+
     # 📌 KAKAO API KEY 로드
     app.config['KAKAO_API_KEY'] = os.getenv("KAKAO_API_KEY")
     if not app.config['KAKAO_API_KEY']:
         raise ValueError("❌ KAKAO_API_KEY가 설정되지 않았습니다! .env 파일을 확인하세요.")
     app.config['TEMPLATES_AUTO_RELOAD'] = True
 
+
+
     # 📌 DB 설정
     db.init_app(app)
     migrate.init_app(app, db)
 
-    #  📌 블루프린트 등록
+
+
+    # 📌 블루프린트 등록
     app.register_blueprint(login_bp)
     app.register_blueprint(admin_bp, url_prefix=app.config['ADMIN_SERVICE_URL'])
     app.register_blueprint(map_bp, url_prefix=app.config['MAP_SERVICE_URL'])
     app.register_blueprint(reservation_bp, url_prefix=app.config['RESERVATION_SERVICE_URL'])
     app.register_blueprint(parkinglot_bp)
-
     # app.register_blueprint(reservation_detail_bp, url_prefix=app.config['RESERVATION_DETAIL_SERVICE_URL'])
 
     return app

--- a/services/admin_service/routes.py
+++ b/services/admin_service/routes.py
@@ -15,7 +15,6 @@ admin_bp = Blueprint('admin_bp', __name__)
 def login_route():
     return login()
 
-
 @login_bp.route('/role_check')
 def role_check_route():
     return role_check()

--- a/services/admin_service/views/auth.py
+++ b/services/admin_service/views/auth.py
@@ -1,10 +1,10 @@
 from flask import render_template, redirect, url_for, session
 from services.common.oauth import oauth
 from flask import current_app
+import os
 
 def login():
-    return oauth.oidc.authorize_redirect(current_app.config['AUTHORIZE_REDIRECT_URL'])
-
+    return oauth.oidc.authorize_redirect(os.getenv("AUTHORIZE_REDIRECT_URL"))
 
 def logout():
     session.pop('user', None)


### PR DESCRIPTION
- oauth의 attributeerror: no such client: oidc
oauth = OAuth(app)를 oauth.init_app(app)로 수정

- 로그인 불가 문제
로그인 관련 정보들(client_secret, redirect_url, secret_key..) 설정 관련. 
주요 정보는 .env에서 관리